### PR TITLE
feat: add RandHex format

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,7 @@ import (
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz" + "0123456789"
+const hexCharset = "0123456789abcdef"
 
 var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
@@ -22,6 +23,10 @@ func stringWithCharset(length int, charset string) string {
 
 func GetStringId(length int) string {
 	return stringWithCharset(length, charset)
+}
+
+func GetHexString(length int) string {
+	return stringWithCharset(length, hexCharset)
 }
 
 func GetUuid() string {


### PR DESCRIPTION
| Format / Dictionary         | Length | Approx. Entropy | Possible Combinations           | Notes                                              |
|-----------------------------|---------|------------------|----------------------------------|----------------------------------------------------|
| `[a-z0-9]` (36)             | 16      | ~83 bits         | ~7.96 × 10²⁴                     | Lowercase letters and digits only                  |
| `[a-z0-9]` (36)             | 25      | ~128 bits        | ~3.4 × 10³⁸                      | Matches 128-bit entropy using base36               |
| `[a-zA-Z0-9]` (62)          | 16      | ~95 bits         | ~4.77 × 10²⁸                     | Full alphanumeric                                  |
| `[a-zA-Z0-9]` (62)          | 22      | ~128 bits        | ~3.2 × 10³⁸                      | Needed to match 128-bit entropy                    |
| Hexadecimal (`0-9a-f`)      | 32      | 128 bits         | ~3.4 × 10³⁸                      | 16 bytes in base16 representation                  |
| UUID v4 (formatted)         | 36      | 122 bits         | ~5.3 × 10³⁶                      | Some bits fixed by UUID spec (version + variant)   |

base36, base62, etc. son texto puro, ocupan 1 byte por carácter, y no tienen representación binaria directa (Solo Hex y UUID pueden guardarse eficientemente como 16 bytes binarios)